### PR TITLE
Fix migration index

### DIFF
--- a/_tests/index.js
+++ b/_tests/index.js
@@ -121,7 +121,7 @@ tap.test('getMigrationByName', test => {
   test.test('if there is no match', test => {
     const name = 'the-world-is-quiet-here'
     const index = getMigrationByName(name, migrations)
-    test.equal(index, null, 'it should return null')
+    test.equal(index, -1, 'it should return -1')
     test.end()
   })
 

--- a/index.js
+++ b/index.js
@@ -41,12 +41,7 @@ function * getTargetMigrations (direction, currentMigration, migrations) {
 
 function getTargetMigration (direction, currentMigration, migrations) {
   const sortedMigrations = sortMigrations(migrations)
-
-  // TODO: Unit test me.
-  const currentMigrationIndex = typeof currentMigration === 'undefined'
-    ? -1
-    : getMigrationByName(currentMigration, sortedMigrations)
-
+  const currentMigrationIndex = getMigrationByName(currentMigration, sortedMigrations)
   return sortedMigrations[currentMigrationIndex + direction] || null
 }
 
@@ -55,12 +50,8 @@ function sortMigrations (migrations) {
 }
 
 function getMigrationByName (name, migrations) {
-  const index = migrations.findIndex(migration =>
+  return migrations.findIndex(migration =>
     migration.name === name)
-
-  return index === -1
-    ? null
-    : index
 }
 
 module.exports = {


### PR DESCRIPTION
Do not skip to migration index 1 if the current migration is null or does not exist (closes #2).